### PR TITLE
Fixed compatibility with postal.federation

### DIFF
--- a/src/postal.request-response.js
+++ b/src/postal.request-response.js
@@ -115,6 +115,8 @@
 		}
 		oldPub.call( this, envelope );
 	};
+	
+	_.extend(postal.publish, oldPub);
 
 	return postal;
 } ));


### PR DESCRIPTION
postal.federation adds some properties to `postal.publish` which need to be added back for everything to work nicely. 
